### PR TITLE
Removing Facebook Login Feature

### DIFF
--- a/app/assets/stylesheets/frontend/devise/registrations/new.scss
+++ b/app/assets/stylesheets/frontend/devise/registrations/new.scss
@@ -52,9 +52,9 @@
 // hotfix for login button
 #submit.login { margin-top: 4rem; }
 
-#facebook-login {
-  margin-top: calc(3rem + 71px);
-}
+// #facebook-login {
+//   margin-top: calc(3rem + 71px);
+// }
 
 
  

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,17 +15,22 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
-  def facebook
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+  
+  # 05 Jul., '19- Facebook would not whitelist our domain,
+  # "https://tonight-lets-drink-drink.herokuapp.com", so the FB login
+  # feature is taken out for now.
 
-    if @user.persisted?
-      sign_in_and_redirect @user, :event => :authentication
-      set_flash_message(:notice, :success, :kind => "Facebook") if is_navigational_format?
-    else
-      session["devise.facebook_data"] = request.env["omniauth.auth"]
-      redirect_to new_user_registration_url
-    end
-  end
+  # def facebook
+  #   @user = User.from_omniauth(request.env["omniauth.auth"])
+
+  #   if @user.persisted?
+  #     sign_in_and_redirect @user, :event => :authentication
+  #     set_flash_message(:notice, :success, :kind => "Facebook") if is_navigational_format?
+  #   else
+  #     session["devise.facebook_data"] = request.env["omniauth.auth"]
+  #     redirect_to new_user_registration_url
+  #   end
+  # end
 
   # 認證失敗
   def failure

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_one :identity
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, :omniauth_providers => [:google_oauth2, :facebook]
+         :recoverable, :rememberable, :validatable, :omniauthable, :omniauth_providers => [:google_oauth2] # :facebook
          # :google_oauth2 是在 controller 中設定的 instance method
 
   validates :email, :encrypted_password, :weight, presence: true

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -19,7 +19,7 @@
     <i class="fa fa-google-plus"></i> continue with Google 
   <% end %>
 
-  <%= link_to omniauth_authorize_path(resource_name, 'facebook'), id: "facebook-login", class: "btn btn-index" do %>
-    <i class="fa fa-facebook"></i> continue with Facebook 
-  <% end %>
+  <%#= link_to omniauth_authorize_path(resource_name, 'facebook'), id: "facebook-login", class: "btn btn-index" do %>
+  <!--  <i class="fa fa-facebook"></i> continue with Facebook -->
+  <%# end %>
 <% end %> 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
   config.omniauth :google_oauth2, ENV["google_public_key"], ENV["google_private_key"],{access_type: "offline", approval_prompt: ""}  # omniauth.auth
 
   #                                                                                               URL needs to be changed to the domain of the app
-  config.omniauth :facebook, ENV["facebook_app_id"], ENV["facebook_app_secret"], callback_url: ENV["facebook_callback_url"]
+  # config.omniauth :facebook, ENV["facebook_app_id"], ENV["facebook_app_secret"], callback_url: ENV["facebook_callback_url"]
 
 
   # ==> Warden configuration


### PR DESCRIPTION
05 Jul., '19- Facebook would not whitelist our domain,
"https://tonight-lets-drink-drink.herokuapp.com", so the FB login
feature is taken out for now.