### PR TITLE
Fix Styles for User/Calc Pages

### DIFF
--- a/app/assets/stylesheets/frontend/about.scss
+++ b/app/assets/stylesheets/frontend/about.scss
@@ -10,7 +10,21 @@
 }
 
 // style for member card
-.col-12.col-md-6.col-lg-3.item { padding-bottom: 3rem; }
+.col-12.col-md-6.col-lg-3.item { 
+  padding-bottom: 3rem; 
+  
+  .card-title { color: #434bdf; }
+  
+  .card-body {
+    padding: 0.5rem 1.25rem;
+
+    p.card-text { 
+      font-size: 13px; 
+    }
+  }
+}
+
+
 
 .btn.btn-index {
   color: #fff;

--- a/app/assets/stylesheets/frontend/animation/animation_man-figure.scss
+++ b/app/assets/stylesheets/frontend/animation/animation_man-figure.scss
@@ -114,7 +114,7 @@
     }
 
     button#to-time-unit {
-      bottom: -1rem;
+      bottom: -6rem;
     }
   }
 }
@@ -128,12 +128,13 @@
     }
 
     .container-btn {
+      height: 14rem;
       top: 6%;
       transform: none;
     }
 
     button#to-time-unit {
-      bottom: -6rem;
+      bottom: -1rem;
     }
   }
 }
@@ -148,12 +149,12 @@
     }
 
     .container-btn {
-      height: 18rem;
+      height: 14rem;
       top: 13%;
       transform: none;
     }
     button#to-time-unit {
-      bottom: -6rem;
+      bottom: -1rem;
     }
   }
 }

--- a/app/assets/stylesheets/frontend/calc.scss
+++ b/app/assets/stylesheets/frontend/calc.scss
@@ -26,7 +26,7 @@
   font-weight: 600;
   border-radius: 3px;
   line-height: 1;
-  padding: 12px 15px;
+  padding: 6px 15px;
   margin: 0 5px;
 }
 #calc-drinks {
@@ -149,7 +149,7 @@ button#to-result {
   font-weight: 600;
   border-radius: 3px;
   line-height: 1;
-  padding: 12px 30px
+  padding: 6px 30px
 }
 .label_name-user-define { 
   display: block; 
@@ -188,14 +188,8 @@ button#to-result {
 
 
 // RWD section
-// // Support for iPhone 5
-@media screen and (max-width: 320px) and (max-height: 568px) {
-  #calc-drinks.calc-drinks-mini {
-    height: 80px;
-  }
-}
 // // for cellphones
-@media screen and (max-width: 767px) and (min-height: 569px) {
+@media screen and (max-width: 767px) {
   #result-step {
     height: 75vh;
   }
@@ -203,14 +197,25 @@ button#to-result {
     height: 75vh;
   }
 
+  #calc-drinks { height: 150px; }
   // for '/calc/user_define/'
   #calc-drinks.calc-drinks-mini {
-    height: 160px;
+    height: 80px;
   }
 }
+// // Support for iPhone 5
+@media screen and (max-width: 320px) and (max-height: 568px) {
+  #calc-drinks { height: 150px; }
+
+  #calc-drinks.calc-drinks-mini {
+    height: 80px;
+  }
+}
+
+
 // // for tablets
 @media screen and (max-width: 991px) {
   .content-left-wrapper{
-    height: 100vh;
+    height: 88vh;
   }
 }

--- a/app/assets/stylesheets/frontend/devise/registrations/edit.scss
+++ b/app/assets/stylesheets/frontend/devise/registrations/edit.scss
@@ -1,7 +1,8 @@
 .sign-up.edit-user-page {
   display: block;
   margin: auto;
-  margin-top: 2rem;
+  margin-top: 0;
+  padding-top: 1rem;
   width: 14.5rem;
   white-space: nowrap;
   text-align: center;

--- a/app/assets/stylesheets/frontend/devise/registrations/new.scss
+++ b/app/assets/stylesheets/frontend/devise/registrations/new.scss
@@ -1,7 +1,7 @@
 .sign-up {
   display: block;
   margin: auto;
-  padding-top: 2rem;
+  padding-top: 1rem;
   left: 0;
   right: 0;
   width: 6rem;

--- a/app/assets/stylesheets/frontend/devise/shared/links.scss
+++ b/app/assets/stylesheets/frontend/devise/shared/links.scss
@@ -1,4 +1,4 @@
 #google_oauth2-login {
   border-radius: 7px;
-  margin-top: 3rem;
+  margin-top: 5rem;
 }

--- a/app/assets/stylesheets/frontend/shared/modal.scss
+++ b/app/assets/stylesheets/frontend/shared/modal.scss
@@ -1,0 +1,11 @@
+@media screen and (max-width: 767px) {
+  .modal-dialog {
+    .modal-dialog-centered {
+      height: 88vh;
+
+      .modal-calc {
+        height: 86vh;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/vendor/wilio/style.scss
+++ b/app/assets/stylesheets/vendor/wilio/style.scss
@@ -1180,7 +1180,7 @@ span.error:after {
   border-radius: 3px;
   font-size: 14px;
   font-size: 0.875rem;
-  height: calc(2.55rem + 2px);
+  // height: calc(2.55rem + 2px);
 }
 .form-control:focus {
   box-shadow: none;

--- a/app/views/calcs/record_user_define.html.erb
+++ b/app/views/calcs/record_user_define.html.erb
@@ -180,7 +180,7 @@
     <!-- Modal terms -->
     <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog"
       aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-dialog modal-dialog-centered modal-calc" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title" id="exampleModalLongTitle">心情愉悅： 啤酒 1.7 杯</h4>

--- a/app/views/calcs/show.html.erb
+++ b/app/views/calcs/show.html.erb
@@ -167,7 +167,7 @@
     <!-- Modal terms -->
     <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog"
       aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-dialog modal-dialog-centered modal-calc" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title" id="exampleModalLongTitle">心情愉悅： 啤酒 1.7 杯</h4>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -5,8 +5,7 @@
       <div class="card">
         <img class="card-img-top" src="https://avatars2.githubusercontent.com/u/30727089?s=460&v=4">
         <div class="card-body">
-          <h5 class="card-title">韓政璇</h5>
-          <h6><a href="mailto:chenghsuan.han@gmail.com">chenghsuan.han@gmail.com</a></h6>
+          <a href="https://github.com/dannyh79"><h5 class="card-title">韓政璇</h5></a>
           <p class="card-text">拜託別灌我酒，因為我會喝下去</p>
         </div>
       </div>
@@ -16,8 +15,7 @@
       <div class="card">
         <img class="card-img-top" src="https://avatars0.githubusercontent.com/u/49583246?s=400&v=4">
         <div class="card-body">
-          <h5 class="card-title">吳兆召</h5>
-          <h6><a href="mailto:chaowu.dev@gmail.com">chaowu.dev@gmail.com</a></h6>
+          <a href="https://github.com/chaochaowu"><h5 class="card-title">吳兆召</h5></a>
           <p class="card-text">長島冰茶是必點清單</p>
         </div>
       </div>
@@ -27,8 +25,7 @@
       <div class="card">
         <img class="card-img-top" src="https://avatars0.githubusercontent.com/u/48974903?s=400&v=4">
         <div class="card-body">
-          <h5 class="card-title">陳孟寬</h5>
-          <h6><a href="mailto:M.K.Chen@outlook.com">M.K.Chen@outlook.com</a></h6>
+          <a href="https://github.com/mkx777"><h5 class="card-title">陳孟寬</h5></a>
           <p class="card-text">一時喝酒一時爽，一直喝酒一直爽。</p>
         </div>
       </div>
@@ -38,8 +35,7 @@
       <div class="card">
         <img class="card-img-top" src="https://avatars3.githubusercontent.com/u/49578192?s=460&v=4">
         <div class="card-body">
-          <h5 class="card-title">楊怡華</h5>
-          <h6><a href="mailto:evayangms@gmail.com">evayangms@gmail.com</a></h6>
+          <a href="https://github.com/evayangms"><h5 class="card-title">楊怡華</h5></a>
           <p class="card-text">喝酒不開車，開車不喝酒</p>
         </div>
       </div>
@@ -50,11 +46,11 @@
 <div class="container references">
   <table class="table table-striped">
     <tr>
-      <th>公式參考</th>
+      <th class="th">公式參考</th>
       <td><a href="http://www.drinkfox.com/tools/bac-calculator">BAC Calculator</a> by <a href="http://www.drinkfox.com/">DrinkFox</a></td>
     </tr>
     <tr>
-      <th>行為表徵</th>
+      <th class="th">行為表徵</th>
       <td><a href="https://en.wikipedia.org/wiki/Blood_alcohol_content">Blood alcohol content</a> on Wikipedia</td>
     </tr>
   </table>


### PR DESCRIPTION
*This is a duplicate PR from Hotfix merged to Master (#90)*

---
### Changed
- Align member cards' height in about page (#103)

### Fixed
- Fix landing page's modal (#103)
- Fix styles for result/"重新選擇" button, & modal in calc page (#103)
- Fix style for sign-up page (#103)
- Fix style for edit page: non-OAuth user (#103)

### Removed
- Remove error popups' height in record_user_define (#103)